### PR TITLE
chore(ci): GitHub-Actions auf Node-24-fähige Majors anheben

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -41,7 +41,7 @@ jobs:
         run: npm run build
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -53,7 +53,7 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload build output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -66,12 +66,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -80,7 +80,7 @@ jobs:
         run: npm ci
 
       - name: Download build output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist


### PR DESCRIPTION
Node 20 wird auf den GitHub-Runnern **ab 16.06.2026** zwangsweise auf Node 24 umgestellt (Deprecation-Warnung im letzten Deploy-Lauf). Dieser PR hebt die verwendeten Actions auf die aktuellen, Node-24-fähigen Majors:

| Action | vorher | nachher |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

Die genutzten Inputs (`persist-credentials`, `node-version`, `cache`, `name`/`path`, `retention-days`) sind über die Majors stabil. `upload`/`download` teilen seit v4 denselben Artifact-Backend und bleiben kompatibel.

Der `ci`-Job (checkout/setup-node/cache/upload) wird durch diesen PR-Lauf live verifiziert; der `deploy`-Job (download-artifact) läuft erst beim Merge auf master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)